### PR TITLE
Do not skip probe if server from other argo

### DIFF
--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -82,11 +82,8 @@ def clean_up(argo_host, vm_timeout, nova):
             else:
                 # this is another nagios test
                 # we may want to delete it if it's been too long
-                helpers.nagios_out(
-                    "Warning",
-                    "Found server from other argo mon host!",
-                    1,
-                )
+                helpers.debug(f"Found server from {server_mon_host}, "
+                              "triggering probe anyway")
 
 
 def wait_for_status(status, server_id, vm_timeout, nova):


### PR DESCRIPTION
Should fix the case where another argo box is running a probe and we still want to run this
(see [sample execution](https://argo.egi.eu/egi/report-status/OPERATORS/SITES/metrics/identity.cloud.muni.cz/egi.cloud.openstack-vm/2024-08-28T18:08:32Z/WARNING/org.openstack.nova))