### PR TITLE
Add version check for nova

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: github/super-linter/slim@v5
+        uses: github/super-linter/slim@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -261,7 +261,7 @@ def novaprobe():
     helpers.debug("Project OPS, ID: %s" % tenant_id)
 
     # get clients
-    nova = nova_client.Client("2.1", region_name=region, session=ks_session)
+    nova = nova_client.Client("2", region_name=region, session=ks_session)
     glance = glanceclient.Client("2", region_name=region, session=ks_session)
     neutron = neutron_client.Client(region_name=region, session=ks_session)
 

--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -17,6 +17,7 @@ import json
 import os
 import socket
 import time
+import traceback
 
 import glanceclient
 import neutronclient.v2_0.client as neutron_client
@@ -158,7 +159,7 @@ def get_network_id(project_id, neutron):
         return None
 
 
-def main():
+def novaprobe():
     argnotspec = []
     parser = argparse.ArgumentParser()
     parser.add_argument("--endpoint", dest="endpoint", nargs="?")
@@ -260,9 +261,11 @@ def main():
     helpers.debug("Project OPS, ID: %s" % tenant_id)
 
     # get clients
-    nova = nova_client.Client("2", region_name=region, session=ks_session)
+    nova = nova_client.Client("2.1", region_name=region, session=ks_session)
     glance = glanceclient.Client("2", region_name=region, session=ks_session)
     neutron = neutron_client.Client(region_name=region, session=ks_session)
+
+    helpers.debug("Nova version: %s" % nova.versions.get_current().version)
 
     if not argholder.image:
         image = get_image(argholder.appdb_img, glance)
@@ -320,6 +323,13 @@ def main():
             % (server_id, server_createt, server_deletet),
             2,
         )
+
+def main():
+    try:
+        novaprobe()
+    except Exception as e:
+        helpers.debug(traceback.format_exc())
+        helpers.nagios_out("Critical", "Unexpected error: %s" % e, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This will show the nova version in the output of the probe so we can understand the current status of the infrastructure. 

It also adds some wrapping in `main` for better capturing the errors in case they show up