### PR TITLE
Support registry.egi.eu images

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: devel
-          VALIDATE_PYTHON_PYLINT: true
+          VALIDATE_PYTHON_PYLINT: false
           VALIDATE_GROOVY: false
-          VALIDATE_JSON: true
+          VALIDATE_JSON_PRETTIER: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,67 +2,67 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment,
-we as contributors and maintainers pledge to making participation
-in our project and our community a harassment-free experience for everyone,
-regardless of age, body size, disability, ethnicity, gender identity and
-expression, level of experience, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
 ## Our Standards
 
-Examples of behaviour that contributes to creating a positive environment include:
+Examples of behaviour that contributes to creating a positive environment
+include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behaviour by participants include:
 
-* The use of sexualised language or imagery and unwelcome sexual attention or
+- The use of sexualised language or imagery and unwelcome sexual attention or
   advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
-behaviour and are expected to take appropriate and fair corrective action
-in response to any instances of unacceptable behaviour.
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
 
-Project maintainers have the right and responsibility to remove, edit,
-or reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily
-or permanently any contributor for other behaviours that they deem
-inappropriate, threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviours that they deem inappropriate, threatening,
+offensive, or harmful.
 
 ## Scope
 
 This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
-Examples of representing a project or community include using an official
-e-mail address, posting via an official social media account, or acting
-as an appointed representative at an online or offline event.
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behaviour may be
-reported by contacting the  ARGO Team.
-The project team will review and investigate all complaints, and will respond
-in a way that it deems appropriate to the circumstances.
-The project team is obligated to maintain confidentiality with regard to the
-reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the ARGO Team. The project team will review and
+investigate all complaints, and will respond in a way that it deems appropriate
+to the circumstances. The project team is obligated to maintain confidentiality
+with regard to the reporter of an incident. Further details of specific
+enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct
-in good faith may face temporary or permanent repercussions as determined
-by other members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
 
 ## Attribution
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,46 +1,40 @@
 {
-    "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-    "@type": "SoftwareSourceCode",
-    "license": "https://spdx.org/licenses/Apache-2.0.html",
-    "codeRepository": "https://github.com/ARGOeu-Metrics/argo-probe-fedcloud.git",
-    "dateCreated": "2024-12-19",
-    "datePublished": "2024-12-19",
-    "dateModified": "2024-12-19",
-    "downloadUrl": "https://github.com/ARGOeu-Metrics/argo-probe-fedcloud/archive/refs/heads/master.zip",
-    "issueTracker": "https://github.com/ARGOeu-Metrics/argo-probe-fedcloud/issues",
-    "name": "Argo Probe Fedcloud",
-    "version": "0.10.2",
-    "description": "This package includes probes for EGI FedCloud services. Currently, it supports the following tests: a) Openstack Nova, b) OpenStack Swift, c) FedCloud Accounting Freshness, d) Cloud info provider freshness",
-    "applicationCategory": "monitoring service",
-    "developmentStatus": "active",
-    "isPartOf": "https://argoeu.github.io/argo-monitoring",
-    "funder": {
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "license": "https://spdx.org/licenses/Apache-2.0.html",
+  "codeRepository": "https://github.com/ARGOeu-Metrics/argo-probe-fedcloud.git",
+  "dateCreated": "2024-12-19",
+  "datePublished": "2024-12-19",
+  "dateModified": "2024-12-19",
+  "downloadUrl": "https://github.com/ARGOeu-Metrics/argo-probe-fedcloud/archive/refs/heads/master.zip",
+  "issueTracker": "https://github.com/ARGOeu-Metrics/argo-probe-fedcloud/issues",
+  "name": "Argo Probe Fedcloud",
+  "version": "0.10.2",
+  "description": "This package includes probes for EGI FedCloud services. Currently, it supports the following tests: a) Openstack Nova, b) OpenStack Swift, c) FedCloud Accounting Freshness, d) Cloud info provider freshness",
+  "applicationCategory": "monitoring service",
+  "developmentStatus": "active",
+  "isPartOf": "https://argoeu.github.io/argo-monitoring",
+  "keywords": [
+    "monitoring",
+    "metric",
+    "argoeu",
+    "probe",
+    "FedCloud",
+    "Openstack Nova",
+    "OpenStack Swift",
+    "Cloud info provider freshness"
+  ],
+  "programmingLanguage": ["Python", "script"],
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Katarina",
+      "familyName": "Zailac",
+      "email": "Katarina.Zailac@srce.hr",
+      "affiliation": {
         "@type": "Organization",
-    },
-    "keywords": [
-        "monitoring",
-        "metric",
-        "argoeu",
-        "probe",
-        "FedCloud", 
-        "Openstack Nova", 
-        "OpenStack Swift",
-        "Cloud info provider freshness"
-    ],
-    "programmingLanguage": [
-        "Python",
-        "script"
-    ],
-    "author": [
-        {
-            "@type": "Person",
-            "givenName": "Katarina",
-            "familyName": "Zailac",
-            "email": "Katarina.Zailac@srce.hr",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "SRCE"
-            }
-        }
-    ]
+        "name": "SRCE"
+      }
+    }
+  ]
 }

--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -281,7 +281,7 @@ def novaprobe():
     helpers.debug("Nova version: %s" % nova.versions.get_current().version)
 
     if not argholder.image:
-        if argholder.registry_image:
+        if argholder.registry_img:
             image = get_registry_image(argholder.registry_img, glance)
         if not image and argholder.appdb_img:
             image = get_appdb_image(argholder.appdb_img, glance)

--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -204,9 +204,15 @@ def novaprobe():
             "Unknown", "cert or access-token command-line arguments not specified", 3
         )
 
-    if argholder.image is None and argholder.appdb_img is None and argholder.registry_img is None:
+    if (
+        argholder.image is None
+        and argholder.appdb_img is None
+        and argholder.registry_img is None
+    ):
         helpers.nagios_out(
-            "Unknown", "image, appdb-image or registry_img command-line arguments not specified", 3
+            "Unknown",
+            "image, appdb-image or registry_img command-line arguments not specified",
+            3,
         )
 
     if len(argnotspec) > 0:

--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -32,11 +32,8 @@ SERVER_NAME = "cloudmonprobe-servertest"
 
 def get_registry_image(registry_id, glance):
     for image in glance.images.list():
-        if image.get("ad:appid", "") == registry_id:
-            return image
-        # TODO: this is to be deprecated as sites move to newer cloudkeeper
         attrs = json.loads(image.get("APPLIANCE_ATTRIBUTES", "{}"))
-        if attrs.get("ad:appid", "") == registry_id:
+        if attrs.get("eu.egi.cloud.image_ref", "") == registry_id:
             return image
     helpers.debug("Image with registry_id %s not found!" % registry_id)
 

--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -30,7 +30,18 @@ STATUS_SLEEP_TIME = 10
 SERVER_NAME = "cloudmonprobe-servertest"
 
 
-def get_image(appdb_id, glance):
+def get_registry_image(registry_id, glance):
+    for image in glance.images.list():
+        if image.get("ad:appid", "") == registry_id:
+            return image
+        # TODO: this is to be deprecated as sites move to newer cloudkeeper
+        attrs = json.loads(image.get("APPLIANCE_ATTRIBUTES", "{}"))
+        if attrs.get("ad:appid", "") == registry_id:
+            return image
+    helpers.debug("Image with registry_id %s not found!" % registry_id)
+
+
+def get_appdb_image(appdb_id, glance):
     for image in glance.images.list():
         if image.get("ad:appid", "") == appdb_id:
             return image
@@ -171,6 +182,7 @@ def novaprobe():
         "--vm-timeout", dest="vm_timeout", type=int, nargs="?", default=300
     )
     parser.add_argument("--appdb-image", dest="appdb_img", nargs="?")
+    parser.add_argument("--registry-image", dest="registry_img", nargs="?")
     parser.add_argument(
         "--identity-provider", dest="identity_provider", default="egi.eu", nargs="?"
     )
@@ -192,9 +204,9 @@ def novaprobe():
             "Unknown", "cert or access-token command-line arguments not specified", 3
         )
 
-    if argholder.image is None and argholder.appdb_img is None:
+    if argholder.image is None and argholder.appdb_img is None and argholder.registry_img is None:
         helpers.nagios_out(
-            "Unknown", "image or appdb-image command-line arguments not specified", 3
+            "Unknown", "image, appdb-image or registry_img command-line arguments not specified", 3
         )
 
     if len(argnotspec) > 0:
@@ -266,7 +278,10 @@ def novaprobe():
     helpers.debug("Nova version: %s" % nova.versions.get_current().version)
 
     if not argholder.image:
-        image = get_image(argholder.appdb_img, glance)
+        if argholder.registry_image:
+            image = get_registry_image(argholder.registry_img, glance)
+        if not image and argholder.appdb_img:
+            image = get_appdb_image(argholder.appdb_img, glance)
     else:
         image = argholder.image
 


### PR DESCRIPTION
Discover images from registry.egi.eu instead of just AppDB.
Allow both options at the same time so sites have time to transition.