### PR TITLE
Force the usage of active images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,3 @@ This work is co-funded by the [EOSC-hub project](http://eosc-hub.eu/) (Horizon 2
 
 <img alt="EU logo" src="https://wiki.eosc-hub.eu/download/attachments/1867786/eu%20logo.jpeg?version=1&modificationDate=1459256840098&api=v2" height="24">
 <img alt="EOSC-Hub logo" src="https://wiki.eosc-hub.eu/download/attachments/18973612/eosc-hub-web.png?version=1&modificationDate=1516099993132&api=v2" height="24">
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently, it supports the following tests:
 - FedCloud Accounting Freshness
 - Cloud info provider freshness
 
-This work is co-funded by the [EOSC-hub project](http://eosc-hub.eu/) (Horizon 2020) under Grant number 777536. 
+This work is co-funded by the [EOSC-hub project](http://eosc-hub.eu/) (Horizon 2020) under Grant number 777536.
 
 <img alt="EU logo" src="https://wiki.eosc-hub.eu/download/attachments/1867786/eu%20logo.jpeg?version=1&modificationDate=1459256840098&api=v2" height="24">
 <img alt="EOSC-Hub logo" src="https://wiki.eosc-hub.eu/download/attachments/18973612/eosc-hub-web.png?version=1&modificationDate=1516099993132&api=v2" height="24">

--- a/src/argo_probe_fedcloud/novaprobe.py
+++ b/src/argo_probe_fedcloud/novaprobe.py
@@ -36,7 +36,7 @@ def get_image_from_id(image_id, glance):
         image = glance.images.get(image_id)
         if image.status == "active":
             return image
-    except glanceclient.exc.HTTPNotFound as e:
+    except glanceclient.exc.HTTPNotFound:
         pass
     helpers.debug("Image with id %s not found!" % image_id)
     return None


### PR DESCRIPTION
Avoid using images that are not yet ready for running by checking their status. Also properly implement the case where the image id is passed (which was not working at all)